### PR TITLE
Update npm build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha",
     "build": "rollup -c",
-    "build-publish": "rollup -c && uglifyjs build/tensorspace.js -b beautify=false,preamble='\"// https://github.com/tensorspace-team/tensorspace/blob/master/LICENSE\"' --source-map \"root='tensorspace.js',url='tensorspace.min.js.map'\" --output build/tensorspace.min.js",
+    "build-prod": "rollup --config rollup.config.prod.js",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
   },
@@ -23,6 +23,8 @@
     "@tweenjs/tween.js": "^17.2.0",
     "install": "^0.12.1",
     "npm": "^6.4.1",
+    "rollup-plugin-terser": "^4.0.1",
+    "terser": "^3.14.1",
     "three": "^0.98.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "build/tensorspace.module.js",
   "scripts": {
     "test": "mocha",
-    "build": "rollup -c",
-    "build-prod": "rollup --config rollup.config.prod.js",
+    "build": "rollup --config rollup.config.js",
+    "build-npm": "rollup --config rollup.config.npm.js",
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-es2015": "^6.24.1",
     "chai": "^4.2.0",
     "mocha": "^4.1.0",
-    "rollup": "^0.53.4",
+    "rollup": "^0.66.0",
     "uglify-es": "^3.3.10"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,24 +2,42 @@
  * Created by ss on 2018/6/25.
  */
 
-export default [
+ /**
+  * Created by ss on 2018/01/06.
+  */
+ import { terser } from "rollup-plugin-terser";
 
-    {
+ let terserOptions = {
+     output: {
+         ecma: 5,
+         preamble: '// https://github.com/tensorspace-team/tensorspace/blob/master/LICENSE',
+     },
+ }
 
-        input: 'src/tensorspace.js',
-        output: [
-
-            {
-
-                format: 'iife',
-                file: 'build/tensorspace.js',
-                name: "TSP",
-				sourcemap: true
-
-            }
-
-        ]
-
-    }
-
-];
+ export default [
+     // Build regular version for development
+     {
+         input: 'src/tensorspace.js',
+         output: [
+             {
+                 format: 'iife',
+                 file: 'build/tensorspace.js',
+                 name: "TSP",
+                 sourcemap: true,
+             }
+         ],
+     },
+     // Build minified version for development
+     {
+         input: 'src/tensorspace.js',
+         plugins: [terser(terserOptions)],
+         output: [
+             {
+                 format: 'iife',
+                 file: 'build/tensorspace.min.js',
+                 name: "TSP",
+                 sourcemap: true,
+             }
+         ],
+     },
+ ]

--- a/rollup.config.npm.js
+++ b/rollup.config.npm.js
@@ -11,6 +11,18 @@ let terserOptions = {
 }
 
 export default [
+    // Build regular version for distribution
+    {
+        input: 'src/tensorspace.js',
+        output: [
+            {
+                format: 'iife',
+                file: 'dist/tensorspace.js',
+                name: "TSP",
+                sourcemap: true,
+            }
+        ],
+    },
     // Build minified version for distribution
     {
         input: 'src/tensorspace.js',
@@ -18,7 +30,7 @@ export default [
         output: [
             {
                 format: 'iife',
-                file: 'build/tensorspace.min.js',
+                file: 'dist/tensorspace.min.js',
                 name: "TSP",
                 sourcemap: true,
             }

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -1,0 +1,27 @@
+/**
+ * Created by ss on 2018/01/06.
+ */
+import { terser } from "rollup-plugin-terser";
+
+let terserOptions = {
+    output: {
+        ecma: 5,
+        preamble: '// https://github.com/tensorspace-team/tensorspace/blob/master/LICENSE',
+    },
+}
+
+export default [
+    // Build minified version for distribution
+    {
+        input: 'src/tensorspace.js',
+        plugins: [terser(terserOptions)],
+        output: [
+            {
+                format: 'iife',
+                file: 'build/tensorspace.min.js',
+                name: "TSP",
+                sourcemap: true,
+            }
+        ],
+    },
+]


### PR DESCRIPTION
Switch to terser.js from uglify-es to minify source code for distribution.

Reason:
"uglify-es is no longer maintained and uglify-js does not support ES6+."
refer to: https://github.com/terser-js/terser#why-choose-terser

Testing:
Ran examples in WebStorm