### PR TITLE
Make importing stats.min.js optional in browser #206

### DIFF
--- a/examples/helloworld/helloworld.html
+++ b/examples/helloworld/helloworld.html
@@ -7,7 +7,7 @@
 
     <script src="../lib/three.min.js"></script>
     <script src="../lib/tween.min.js"></script>
-		<script src="../lib/stats.min.js"></script>
+		<!-- <script src="../lib/stats.min.js"></script> -->
     <script src="../lib/tf.min.js"></script>
     <script src="../lib/TrackballControls.js"></script>
     <script src="../../dist/tensorspace.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
 
         runInParent: false,
 
-        captureConsole: false
+        captureConsole: true
       },
 
     reporters: [ 'spec' ],
@@ -39,7 +39,7 @@ module.exports = function(config) {
 
       { pattern: 'test/lib/three.min.js', included: true },
 
-      { pattern: 'test/lib/stats.min.js', included: true },
+      { pattern: 'test/lib/stats.min.js', included: false, served: false },
 
       { pattern: 'test/lib/tween.min.js', included: true },
 

--- a/src/scene/SceneInitializer.js
+++ b/src/scene/SceneInitializer.js
@@ -4,7 +4,7 @@
 
 import * as THREE from "three";
 import * as TWEEN from "@tweenjs/tween.js";
-import * as Stats from "stats-js";
+// import * as Stats from "stats-js";
 import * as TrackballControls from "three-trackballcontrols";
 import { DefaultCameraPos, DefaultLayerDepth } from "../utils/Constant";
 
@@ -82,12 +82,37 @@ SceneInitializer.prototype = {
 		this.scene.background = new THREE.Color( this.backgroundColor );
 
 		if ( this.hasStats ) {
+			import('stats-js')
+				.then((module) => {
 
-			this.stats = new Stats();
-			this.stats.dom.style.position = "absolute";
-			this.stats.dom.style.zIndex = "1";
-			this.stats.showPanel( 0 );
-			this.container.appendChild( this.stats.dom );
+					this.stats = new module();
+					this.stats.dom.style.position = "absolute";
+					this.stats.dom.style.zIndex = "1";
+					this.stats.showPanel( 0 );
+					this.container.appendChild( this.stats.dom );
+
+				})
+				.catch(() => {
+
+					if ( typeof Stats !== 'undefined' ) {
+
+						this.stats = new Stats();
+						this.stats.dom.style.position = "absolute";
+						this.stats.dom.style.zIndex = "1";
+						this.stats.showPanel( 0 );
+						this.container.appendChild( this.stats.dom );
+
+					} else if ( typeof window === 'undefined' ) {
+
+						console.error('Please import stats-js');
+
+					} else  {
+
+						console.error('Please include  <script> tag');
+
+					}
+
+				});
 
 		}
 


### PR DESCRIPTION
Testing:
- `npm run test-e2e`: passed
- Ran helloworld example **with** and **without** <script src="../lib/stats.min.js"></script>
- Ran angular example with **stats=true** and **stats=false**

Summary:
- Removed stats.min.js in helloworld example
- Not serving test/lib/stats.min.js when running e2e test
- Remove <script src="/base/test/lib/stats.min.js"> from test/e2e/template.html
- Dynamically import stats-js